### PR TITLE
fix missing host property from http options

### DIFF
--- a/hijack/http.js
+++ b/hijack/http.js
@@ -16,11 +16,12 @@ function start(apm) {
       return protocolRequestMethods[protocol].call(this, options, callback);
     }
 
-    const apmOptions =
-      typeof options === "string" ? url.parse(options) : options;
-    const eventName = `${apmOptions.method}:${protocol}//${
-      apmOptions.headers.host
-    }${apmOptions.path}`;
+    const apmOptions = typeof options === "string" ? url.parse(options) : options;
+
+    let { method, host, path } = apmOptions;
+    if (!host) host = apmOptions.hostname;
+
+    const eventName = `${method}:${protocol}//${host}${path}`;
     const eventType = "http.outcoming";
     const transaction =
       apm.currentTransaction || apm.startTransaction(eventName, eventType);


### PR DESCRIPTION
Error occurred when apmOptions has no headers property, leading to an `Cannot read property 'host' from undefined` Error.
This happens when `url.parse()` is used as it does not return a headers property.
Happens for some options object as well (eg algolia instantsearch)
Using host or hostname property solves this issue.