### PR TITLE
Early registering for http in tracking

### DIFF
--- a/instrumenting/http-in.js
+++ b/instrumenting/http-in.js
@@ -1,0 +1,25 @@
+import { HTTP_INCOMING, EXECUTION, SENDING } from '../constants';
+
+function start(agent, WebApp) {
+  WebApp.connectHandlers.use(function(req, res, next) {
+    const transaction = agent.startTransaction(`${req.method}:${req.url}`, HTTP_INCOMING);
+    const span = agent.startSpan(EXECUTION);
+
+    res.on('finish', () => {
+      span.end();
+      transaction.__span = agent.startSpan(SENDING);
+    });
+    res.socket.on('close', () => {
+      if (transaction) {
+        if (transaction.__span) {
+          transaction.__span.end();
+        }
+        transaction.end();
+      }
+    });
+
+    next();
+  });
+}
+
+module.exports = start;

--- a/instrumenting/http-out.js
+++ b/instrumenting/http-out.js
@@ -4,7 +4,7 @@ import shimmer from 'shimmer';
 
 import { HTTP, HTTP_OUTCOMING } from '../constants';
 
-function start(agent, WebApp) {
+function start(agent) {
   shimmer.wrap(http, 'request', function(original) {
     return function(options, callback) {
       // we don't want to catch elastic requests, it causes recursive requests handling

--- a/instrumenting/http-out.js
+++ b/instrumenting/http-out.js
@@ -2,10 +2,9 @@ import http from 'http';
 import url from 'url';
 import shimmer from 'shimmer';
 
-import { HTTP, HTTP_OUTCOMING, HTTP_INCOMING, EXECUTION, SENDING } from '../constants';
+import { HTTP, HTTP_OUTCOMING } from '../constants';
 
 function start(agent, WebApp) {
-  // monitor outcoming http requests
   shimmer.wrap(http, 'request', function(original) {
     return function(options, callback) {
       // we don't want to catch elastic requests, it causes recursive requests handling
@@ -51,27 +50,6 @@ function start(agent, WebApp) {
 
       return request;
     };
-  });
-
-  // monitor incoming http request
-  WebApp.connectHandlers.use('/', function(req, res, next) {
-    const transaction = agent.startTransaction(`${req.method}:${req.url}`, HTTP_INCOMING);
-    const span = agent.startSpan(EXECUTION);
-
-    res.on('finish', () => {
-      span.end();
-      transaction.__span = agent.startSpan(SENDING);
-    });
-    res.socket.on('close', () => {
-      if (transaction) {
-        if (transaction.__span) {
-          transaction.__span.end();
-        }
-        transaction.end();
-      }
-    });
-
-    next();
   });
 }
 

--- a/meteor-elastic-apm.js
+++ b/meteor-elastic-apm.js
@@ -6,7 +6,8 @@ const Agent = require('elastic-apm-node');
 const { Session, Subscription, MongoCursor } = require('./meteorx');
 
 const instrumentMethods = require('./instrumenting/methods');
-const instrumentHttp = require('./instrumenting/http');
+const instrumentHttpIn = require('./instrumenting/http-in');
+const instrumentHttpOut = require('./instrumenting/http-out');
 const instrumentSession = require('./instrumenting/session');
 const instrumentSubscription = require('./instrumenting/subscription');
 const instrumentAsync = require('./instrumenting/async');
@@ -33,7 +34,8 @@ shimmer.wrap(Agent, 'start', function(startAgent) {
           hackDB();
 
           instrumentMethods(Agent, Meteor);
-          instrumentHttp(Agent, WebApp);
+          instrumentHttpOut(Agent, WebApp);
+          instrumentHttpIn(Agent, WebApp);
           instrumentSession(Agent, Session);
           instrumentSubscription(Agent, Subscription);
           instrumentAsync(Agent, Fibers);


### PR DESCRIPTION
Register the `connect()` handler as early as possible. All `connect()` handlers defined before will not be tracked. Registering this handler should therefore not be delayed.