### PR TITLE
Http in use url routes

### DIFF
--- a/instrumenting/http-in.js
+++ b/instrumenting/http-in.js
@@ -5,7 +5,7 @@ function start(agent, WebApp) {
     const transaction = agent.startTransaction(`${req.method}:${req.url}`, HTTP_INCOMING);
     transaction.setLabel('url', `${req.url}`);
     transaction.setLabel('method', `${req.method}`);
-    
+
     const span = agent.startSpan(EXECUTION);
 
     res.on('finish', () => {
@@ -13,11 +13,11 @@ function start(agent, WebApp) {
       if (req.originalUrl.endsWith(req.url.slice(1)) && req.url.length > 1) {
         route = req.originalUrl.slice(0, -1 * (req.url.length - 1));
       }
-  
+
       if (route.endsWith('/')) {
         route = route.slice(0, -1);
       }
-  
+
       if (route) {
         transaction.name = `${req.method}:${route}`;
         transaction.setLabel('route', `${route}`);

--- a/instrumenting/http-in.js
+++ b/instrumenting/http-in.js
@@ -3,6 +3,9 @@ import { HTTP_INCOMING, EXECUTION, SENDING } from '../constants';
 function start(agent, WebApp) {
   WebApp.connectHandlers.use(function(req, res, next) {
     const transaction = agent.startTransaction(`${req.method}:${req.url}`, HTTP_INCOMING);
+    transaction.setLabel('url', `${req.url}`);
+    transaction.setLabel('method', `${req.method}`);
+    
     const span = agent.startSpan(EXECUTION);
 
     res.on('finish', () => {
@@ -17,6 +20,7 @@ function start(agent, WebApp) {
   
       if (route) {
         transaction.name = `${req.method}:${route}`;
+        transaction.setLabel('route', `${route}`);
       }
 
       span.end();

--- a/instrumenting/http-in.js
+++ b/instrumenting/http-in.js
@@ -6,6 +6,19 @@ function start(agent, WebApp) {
     const span = agent.startSpan(EXECUTION);
 
     res.on('finish', () => {
+      let route = req.originalUrl;
+      if (req.originalUrl.endsWith(req.url.slice(1)) && req.url.length > 1) {
+        route = req.originalUrl.slice(0, -1 * (req.url.length - 1));
+      }
+  
+      if (route.endsWith('/')) {
+        route = route.slice(0, -1);
+      }
+  
+      if (route) {
+        transaction.name = `${req.method}:${route}`;
+      }
+
       span.end();
       transaction.__span = agent.startSpan(SENDING);
     });


### PR DESCRIPTION
Includes the changes of #21 

For me the metrics for each individual route is important instead of the single specific request. Therefore, I've here replaced URL by the name of the route, determined by `connect()`.

Since you might still want to see the full URL, I've added it as a label, so this information isn't lost. But the UI will group it by the route name combined with the HTTP method.

If the route could not be determined, the URL is used instead - it basically falls back to the old behavior.